### PR TITLE
Corrigindo tratamento de erro relativo ao envio de pdf maior que 5MB

### DIFF
--- a/src/Controllers/DemandController.js
+++ b/src/Controllers/DemandController.js
@@ -903,6 +903,11 @@ const uploadFile = async (req, res) => {
     const validFields = validation.validateDemandUpdate(
       userName, description, visibility, userSector, userID, important,
     );
+    
+    const MAX_SIZE_5_MEGABYTES = 5 * 1024 * 1024;
+    if (size >= MAX_SIZE_5_MEGABYTES) {
+      return res.status(400).json({ err: "File bigger then 5MB." })
+    }
 
     if (validFields.length) {
       return res.status(400).json({ status: validFields });

--- a/src/Utils/multer.js
+++ b/src/Utils/multer.js
@@ -2,8 +2,6 @@ const multer = require('multer');
 const path = require('path');
 const crypto = require('crypto');
 
-const MAX_SIZE_5_MEGABYTES = 5 * 1024 * 1024;
-
 module.exports = {
   storage: multer.diskStorage({
 
@@ -21,9 +19,6 @@ module.exports = {
       });
     },
   }),
-  limits: {
-    fileSize: MAX_SIZE_5_MEGABYTES,
-  },
   fileFilter: (req, file, cb) => {
     const allowedFormat = [
       'application/pdf',


### PR DESCRIPTION
## Descrição

Este PR resolve a issue [#41](https://github.com/DITGO/2021-2-SiGeD-Doc/issues/41), que consiste em corrigir o erro no serviço de demanda ao inserir arquivos grandes como anexo, por meio dos seguintes commits:

* [Resolução referente à issue #41](https://github.com/2023-1-GCES-SIGeD/2021-2-SiGeD-Frontend/commit/c406af471a9f3d9ab6f2f8aa3be34251ca72)  - Frontend
* [Corrigindo tratamento de erro relativo ao envio de pdf maior que 5MB](https://github.com/2023-1-GCES-SIGeD/2021-2-SiGeD-Demands/commit/7958e3fbcafdf125dfef5ee4cc1ae9d3e164ea1a) - Backend Demands

## Como isso foi testado
* Por meio dos testes que já existiam no projeto (cobertura se manteve);
* Enviando arquivos que ultrapassam o limite e checando se o arquivo era incluído (o arquivo não foi incluído);
* Enviando arquivos que não ultrapassam o limite e checando se o arquivo era incluído (o arquivo foi incluído).

## Capturas de tela
![Screenshot from 2023-06-28 23-06-44](https://github.com/DITGO/2021-2-SiGeD-Demands/assets/21300624/f58ff30c-9998-4f6e-b796-dbbc07a1a598)

## Tipos de mudança
A partir de agora, ao invés do usuário ser deslogado do sistema, ele será alertado com uma mensagem informando que o arquivo ultrapassou o limite.

### Pareamento: @brunaalmeidasantos