### PR TITLE
Incluir atendimentos dentro da demanda 

### DIFF
--- a/src/Controllers/DemandController.js
+++ b/src/Controllers/DemandController.js
@@ -683,6 +683,7 @@ const createDemandUpdate = async (req, res) => {
     description,
     visibilityRestriction,
     important,
+    treatment,
   } = req.body;
 
   const validFields = validation.validateDemandUpdate(
@@ -692,6 +693,7 @@ const createDemandUpdate = async (req, res) => {
     userSector,
     userID,
     important,
+    treatment,
   );
 
   if (validFields.length) {
@@ -708,6 +710,7 @@ const createDemandUpdate = async (req, res) => {
       description,
       visibilityRestriction,
       important,
+      treatment,
       createdAt: moment
         .utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss'))
         .toDate(),
@@ -740,6 +743,7 @@ const updateDemandUpdate = async (req, res) => {
     visibilityRestriction,
     updateListID,
     important,
+    treatment,
   } = req.body;
 
   const validFields = validation.validateDemandUpdate(
@@ -749,6 +753,7 @@ const updateDemandUpdate = async (req, res) => {
     userSector,
     userID,
     important,
+    treatment,
   );
 
   if (validFields.length) {
@@ -766,6 +771,7 @@ const updateDemandUpdate = async (req, res) => {
           'updateList.$.description': description,
           'updateList.$.visibilityRestriction': visibilityRestriction,
           'updateList.$.important': important,
+          'updateList.$.treatment': treatment,
           'updateList.$.updatedAt': moment
             .utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss'))
             .toDate(),

--- a/src/Models/DemandSchema.js
+++ b/src/Models/DemandSchema.js
@@ -110,6 +110,11 @@ const DemandSchema = new mongoose.Schema({
       require: true,
       default: false,
     },
+    treatment: {
+      type: Boolean,
+      require: true,
+      default: false,
+    },
     createdAt: {
       type: Date,
       require: true,


### PR DESCRIPTION
## Descrição

Esse PR resolve a issue [4](https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/4) que consiste em adicionar um checkbox de atendimento na atualização das demandas e além disso contabilizar os atendimentos.

## Tela de atualização de demandas:

Ao entrar em uma demanda específica, o usuário é capaz de adicionar atendimento à demanda.

## Como foi testado:

* Acessando uma demanda específica
* Preenchendo o checkbox de atendimento e atualizando a demanda
* Visualizando a edição da nova atualização de demanda

## Capturas de tela:
![Captura de tela de 2023-10-19 11-04-25](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/4c3b19fe-8648-4137-971f-dbe544f0d1f6)
![Captura de tela de 2023-10-19 12-59-15](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/2e59cf2f-30ff-4cba-bb7e-b53922b30ce5)
![Captura de tela de 2023-10-19 12-59-29](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/9a433642-c876-4c3f-b510-36eb1575f873)
![Captura de tela de 2023-10-19 12-59-33](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/f0369c6a-e9e1-49ff-8c94-35b954f321d4)

# Pareamento: @brbsg

## Issue resolvidas com o PR

Repositório DITGO:
resolve https://github.com/DITGO/2021-2-SiGeD-Doc/issues/26

Repositório GCES-2023/2:
resolve https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/4


