### PR TITLE
fix: modificado a logica para contar os setores anteriores no grafico…

### DIFF
--- a/src/Controllers/DemandController.js
+++ b/src/Controllers/DemandController.js
@@ -328,8 +328,20 @@ const demandsSectorsStatistic = async (req, res) => {
 
   const aggregatorOpts = [
     {
+      $unwind: '$sectorHistory',
+    },
+    {
+      $match: {
+        createdAt: {
+          $gte: new Date(initialDate),
+          $lte: new Date(completeFinalDate),
+        },
+        open: isActive,
+      },
+    },
+    {
       $group: {
-        _id: { $last: '$sectorHistory.sectorID' },
+        _id: '$sectorHistory.sectorID',
         total: { $sum: 1 },
       },
     },


### PR DESCRIPTION
## Descrição

Esse PR resolve a issue https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/6 que consiste em modificar a lógica de criação dos graficos, assim condierando setores o qual a demanda passou e não só o atual.

## Capturas de tela:

### Resultado: 
![image](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/53407780/ce8b4ee4-2ee0-4c34-ae9f-ea11bdd2adf0)

Pareamento: @deboracaires 

## Issue resolvidas com o PR
Repositório GCES-2023/2:
resolve https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/6

